### PR TITLE
add constructor with identifier as param

### DIFF
--- a/autonomous-dialog/src/main/java/com/mrhabibi/autonomousdialog/DialogResult.java
+++ b/autonomous-dialog/src/main/java/com/mrhabibi/autonomousdialog/DialogResult.java
@@ -45,6 +45,20 @@ public class DialogResult {
     }
 
     /**
+     * DialogResult's constructor when you only need to add identifier
+     *
+     * @param resultCode Activity result code
+     * @param identifier Activity dialog identifier
+     */
+    public DialogResult(int resultCode, String identifier) {
+        Intent data = new Intent();
+        data.putExtra("id", identifier);
+
+        this.mData = data;
+        this.mResultCode = resultCode;
+    }
+
+    /**
      * The result is if positive button pressed
      *
      * @param identifier The identifier


### PR DESCRIPTION
banyak usage dari dialog result, cuma membutuhkan result code positive / negative.

sehingga boiler code di beberapa unit test.
```kotlin
val result = DialogResult(
   DialogResult.RESULT_DIALOG_NEGATIVE_BUTTON,
   Intent().apply { putExtra("id", TYPE_ACCEPT_SOLUTION) }
)
```

bisa dipersingkat menjadi
```kotlin
val result = DialogResult(DialogResult.RESULT_DIALOG_NEGATIVE_BUTTON, TYPE_ACCEPT_SOLUTION)
```